### PR TITLE
Fix recursion when lists are used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
 	"name": "yamlnav",
-	"version": "0.0.4",
+	"version": "0.0.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.0.4",
+			"name": "yamlnav",
+			"version": "0.0.6",
 			"dependencies": {
 				"yaml": "^2.0.0-4"
 			},

--- a/src/yaml-path.js
+++ b/src/yaml-path.js
@@ -19,17 +19,18 @@ function parse(content) {
 
 function displayNodes(items, parent, results, { lineCounter }) {
   items.forEach((item) => {
+    let base = (!item.key) ? item : item.key;
 
     let nextParent = {
       path: null,
-      range: item.key.range,
-      line: lineCounter.linePos(item.key.range[0])
+      range: base.range,
+      line: lineCounter.linePos(base.range[0])
     }
 
     if (!parent) {
-      nextParent.path = item.key.value
+      nextParent.path = base.value
     } else {
-      nextParent.path = `${parent.path}.${item.key.value}`
+      nextParent.path = `${parent.path}.${base.value}`
     }
 
     results.push(nextParent)


### PR DESCRIPTION
In cases someone uses lists like the following example, the recursion would error on missing keys/values.

```yaml
---
fruits:
- Apple
- Orange
- Strawberry
- Mango
```